### PR TITLE
Added an option to return a default version when run without a valid tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Gets semver string from a specified tag.
 
 **Required** The tag value.
 
+### `allowNoTag`
+
+**Default**: `false`
+When set to `true` while run on branches and invalid semver tags, will return a default version of `0.0.0`
+
 ## Outputs
 
 ### `prefixed`

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   tag:
     description: 'Tag'
     required: true
+  allowNoTag:
+    description: 'The action will return 0.0.0 when not a tag'
+    default: 'false'
 outputs:
   prefixed:
     description: 'Semver string with a v prefix'

--- a/src/get-semver-from-tag.js
+++ b/src/get-semver-from-tag.js
@@ -18,7 +18,7 @@ async function run() {
             core.setOutput('prefixed', `v${version}`);
 
         } else {
-            if (allowNoTag === 'true') {
+            if (allowNoTag == 'true') {
                 core.setOutput('non-prefixed', '0.0.0');
                 core.setOutput('prefixed', 'v0.0.0');
             } else {

--- a/src/get-semver-from-tag.js
+++ b/src/get-semver-from-tag.js
@@ -6,6 +6,7 @@ async function run() {
     try {
 
         const tagInput = core.getInput('tag');
+        const allowNoTag = core.getInput('allowNoTag');
 
         let version = tagInput.substring(10);
 
@@ -17,7 +18,12 @@ async function run() {
             core.setOutput('prefixed', `v${version}`);
 
         } else {
-            core.setFailed(`\'tag\' input [${tagInput}] contains no version`);
+            if (allowNoTag === 'true') {
+                core.setOutput('non-prefixed', '0.0.0');
+                core.setOutput('prefixed', 'v0.0.0');
+            } else {
+                core.setFailed(`\'tag\' input [${tagInput}] contains no version`);
+            }
         }
 
     } catch (error) {

--- a/tests/get-semver-from-tag.test.js
+++ b/tests/get-semver-from-tag.test.js
@@ -19,6 +19,21 @@ describe('Get semver from tag', () => {
         expect(core.setOutput).toHaveBeenNthCalledWith(2, 'prefixed', 'v1.2.3');
     });
 
+    test('Outputs are default', async () => {
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('refs/tags/non-version')
+            .mockReturnValueOnce('true');
+
+        core.setOutput = jest.fn();
+
+        await run();
+
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'non-prefixed', '0.0.0');
+        expect(core.setOutput).toHaveBeenNthCalledWith(2, 'prefixed', 'v0.0.0');
+    });
+
     test('Action fails elegantly', async () => {
         core.getInput = jest
             .fn()


### PR DESCRIPTION
For situations where someone may want to not have the action fail and return a default version number of `0.0.0` when run on invalid tags or branches